### PR TITLE
Add basic web UI and API routes

### DIFF
--- a/mass_email_server/app/routes/campaigns.py
+++ b/mass_email_server/app/routes/campaigns.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Request, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.database import EmailCampaign
+from ..models.email_models import EmailCampaignCreate
+
+router = APIRouter(prefix="/api/campaigns", tags=["campaigns"])
+
+@router.post("", status_code=201)
+async def create_campaign(campaign: EmailCampaignCreate, request: Request):
+    db: AsyncSession = request.state.db
+    new_campaign = EmailCampaign(
+        name=campaign.name,
+        subject=campaign.subject,
+        html_content=campaign.html_content,
+    )
+    db.add(new_campaign)
+    await db.commit()
+    await db.refresh(new_campaign)
+    return {"id": new_campaign.id}
+
+@router.get("")
+async def list_campaigns(request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(EmailCampaign))
+    campaigns = result.scalars().all()
+    return [
+        {
+            "id": c.id,
+            "name": c.name,
+            "subject": c.subject,
+            "status": c.status,
+            "total_recipients": c.total_recipients,
+        }
+        for c in campaigns
+    ]
+
+@router.get("/{campaign_id}")
+async def get_campaign(campaign_id: int, request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(EmailCampaign).where(EmailCampaign.id == campaign_id))
+    campaign = result.scalar_one_or_none()
+    if campaign is None:
+        raise HTTPException(status_code=404, detail="Campaign not found")
+    return {
+        "id": campaign.id,
+        "name": campaign.name,
+        "subject": campaign.subject,
+        "html_content": campaign.html_content,
+        "status": campaign.status,
+        "total_recipients": campaign.total_recipients,
+    }

--- a/mass_email_server/app/routes/recipients.py
+++ b/mass_email_server/app/routes/recipients.py
@@ -1,0 +1,49 @@
+import csv
+from fastapi import APIRouter, UploadFile, File, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from ..models.database import EmailRecipient
+from ..models.email_models import EmailRecipientCreate
+
+router = APIRouter(prefix="/api/recipients", tags=["recipients"])
+
+@router.post("/import")
+async def import_recipients(file: UploadFile = File(...), request: Request = None):
+    db: AsyncSession = request.state.db
+    content = await file.read()
+    reader = csv.DictReader(content.decode().splitlines())
+    count = 0
+    for row in reader:
+        recipient = EmailRecipient(email=row.get("email"), name=row.get("name"))
+        db.add(recipient)
+        count += 1
+    await db.commit()
+    return {"imported": count}
+
+@router.get("")
+async def list_recipients(request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(EmailRecipient))
+    recipients = result.scalars().all()
+    return [{"id": r.id, "email": r.email, "name": r.name} for r in recipients]
+
+@router.post("")
+async def add_recipient(recipient: EmailRecipientCreate, request: Request):
+    db: AsyncSession = request.state.db
+    rec = EmailRecipient(email=recipient.email, name=recipient.name)
+    db.add(rec)
+    await db.commit()
+    await db.refresh(rec)
+    return {"id": rec.id}
+
+@router.delete("/{recipient_id}")
+async def delete_recipient(recipient_id: int, request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(EmailRecipient).where(EmailRecipient.id == recipient_id))
+    rec = result.scalar_one_or_none()
+    if rec:
+        await db.delete(rec)
+        await db.commit()
+        return {"deleted": True}
+    return {"deleted": False}

--- a/mass_email_server/app/routes/templates.py
+++ b/mass_email_server/app/routes/templates.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Request, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.database import EmailTemplate
+from ..models.email_models import EmailTemplateCreate
+
+router = APIRouter(prefix="/api/templates", tags=["templates"])
+
+@router.post("", status_code=201)
+async def create_template(template: EmailTemplateCreate, request: Request):
+    db: AsyncSession = request.state.db
+    new_tmpl = EmailTemplate(
+        name=template.name,
+        html_content=template.html_content,
+        variables=template.variables,
+    )
+    db.add(new_tmpl)
+    await db.commit()
+    await db.refresh(new_tmpl)
+    return {"id": new_tmpl.id}
+
+@router.get("")
+async def list_templates(request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(EmailTemplate))
+    templates = result.scalars().all()
+    return [
+        {"id": t.id, "name": t.name, "variables": t.variables}
+        for t in templates
+    ]
+
+@router.get("/{template_id}")
+async def get_template(template_id: int, request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(EmailTemplate).where(EmailTemplate.id == template_id))
+    template = result.scalar_one_or_none()
+    if template is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return {
+        "id": template.id,
+        "name": template.name,
+        "html_content": template.html_content,
+        "variables": template.variables,
+    }

--- a/mass_email_server/app/routes/web.py
+++ b/mass_email_server/app/routes/web.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Request, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.database import EmailCampaign
+
+templates = Jinja2Templates(directory="templates/web_templates")
+
+router = APIRouter()
+
+@router.get("/campaigns", response_class=HTMLResponse)
+async def campaigns_page(request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(EmailCampaign))
+    campaigns = result.scalars().all()
+    return templates.TemplateResponse("campaigns.html", {"request": request, "campaigns": campaigns})
+
+@router.get("/campaigns/new", response_class=HTMLResponse)
+async def new_campaign_form(request: Request):
+    return templates.TemplateResponse("new_campaign.html", {"request": request})
+
+@router.post("/campaigns/new")
+async def create_campaign_form(request: Request, name: str = Form(...), subject: str = Form(...), html_content: str = Form(...)):
+    db: AsyncSession = request.state.db
+    campaign = EmailCampaign(name=name, subject=subject, html_content=html_content)
+    db.add(campaign)
+    await db.commit()
+    return RedirectResponse(url="/campaigns", status_code=303)

--- a/mass_email_server/requirements.txt
+++ b/mass_email_server/requirements.txt
@@ -14,3 +14,4 @@ python-dotenv
 email-validator
 psycopg2-binary
 alembic
+python-multipart

--- a/mass_email_server/templates/web_templates/base.html
+++ b/mass_email_server/templates/web_templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Mass Email Server</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">Mass Email Server</a>
+  </div>
+</nav>
+<div class="container">
+    {% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/mass_email_server/templates/web_templates/campaigns.html
+++ b/mass_email_server/templates/web_templates/campaigns.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Email Campaigns</h2>
+<table class="table">
+<thead><tr><th>ID</th><th>Name</th><th>Subject</th></tr></thead>
+<tbody>
+{% for c in campaigns %}
+<tr><td>{{ c.id }}</td><td>{{ c.name }}</td><td>{{ c.subject }}</td></tr>
+{% endfor %}
+</tbody>
+</table>
+<a href="/campaigns/new" class="btn btn-primary">New Campaign</a>
+{% endblock %}

--- a/mass_email_server/templates/web_templates/index.html
+++ b/mass_email_server/templates/web_templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Welcome to Mass Email Server</h1>
+<p>Use the API or web interface to manage campaigns.</p>
+{% endblock %}

--- a/mass_email_server/templates/web_templates/new_campaign.html
+++ b/mass_email_server/templates/web_templates/new_campaign.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Create Campaign</h2>
+<form method="post" action="/campaigns/new">
+  <div class="mb-3">
+    <label class="form-label">Name</label>
+    <input type="text" class="form-control" name="name" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Subject</label>
+    <input type="text" class="form-control" name="subject" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">HTML Content</label>
+    <textarea class="form-control" name="html_content" rows="5" required></textarea>
+  </div>
+  <button type="submit" class="btn btn-success">Create</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- wire up bootstrap-based Jinja2 web templates
- expose API routes for campaigns, templates and recipients
- serve simple web pages for campaign CRUD
- include python-multipart in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d5563694832cace010c23fbc83da