### PR TITLE
Enhance security with API key

### DIFF
--- a/mass_email_server/.env.example
+++ b/mass_email_server/.env.example
@@ -8,3 +8,4 @@ SMTP_USERNAME=your_username
 SMTP_PASSWORD=your_password
 EMAIL_FROM=noreply@example.com
 LOG_LEVEL=DEBUG
+API_KEY=changeme

--- a/mass_email_server/.gitignore
+++ b/mass_email_server/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+logs/
+*.pyc
+*.sqlite
+*.db
+.env
+.env.*
+
+.coverage

--- a/mass_email_server/app/config.py
+++ b/mass_email_server/app/config.py
@@ -13,6 +13,8 @@ class Settings(BaseSettings):
     smtp_password: str = Field("", env="SMTP_PASSWORD")
     email_from: str = Field("noreply@example.com", env="EMAIL_FROM")
 
+    api_key: str = Field("changeme", env="API_KEY")
+
     log_level: str = Field("INFO", env="LOG_LEVEL")
 
     class Config:

--- a/mass_email_server/app/routes/campaigns.py
+++ b/mass_email_server/app/routes/campaigns.py
@@ -1,11 +1,16 @@
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, Request, HTTPException, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.database import EmailCampaign
 from ..models.email_models import EmailCampaignCreate
+from ..security.api_key import verify_api_key
 
-router = APIRouter(prefix="/api/campaigns", tags=["campaigns"])
+router = APIRouter(
+    prefix="/api/campaigns",
+    tags=["campaigns"],
+    dependencies=[Depends(verify_api_key)],
+)
 
 @router.post("", status_code=201)
 async def create_campaign(campaign: EmailCampaignCreate, request: Request):

--- a/mass_email_server/app/routes/recipients.py
+++ b/mass_email_server/app/routes/recipients.py
@@ -1,12 +1,17 @@
 import csv
-from fastapi import APIRouter, UploadFile, File, Request
+from fastapi import APIRouter, UploadFile, File, Request, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from ..models.database import EmailRecipient
 from ..models.email_models import EmailRecipientCreate
+from ..security.api_key import verify_api_key
 
-router = APIRouter(prefix="/api/recipients", tags=["recipients"])
+router = APIRouter(
+    prefix="/api/recipients",
+    tags=["recipients"],
+    dependencies=[Depends(verify_api_key)],
+)
 
 @router.post("/import")
 async def import_recipients(file: UploadFile = File(...), request: Request = None):

--- a/mass_email_server/app/routes/templates.py
+++ b/mass_email_server/app/routes/templates.py
@@ -1,11 +1,16 @@
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, Request, HTTPException, Depends
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.database import EmailTemplate
 from ..models.email_models import EmailTemplateCreate
+from ..security.api_key import verify_api_key
 
-router = APIRouter(prefix="/api/templates", tags=["templates"])
+router = APIRouter(
+    prefix="/api/templates",
+    tags=["templates"],
+    dependencies=[Depends(verify_api_key)],
+)
 
 @router.post("", status_code=201)
 async def create_template(template: EmailTemplateCreate, request: Request):

--- a/mass_email_server/app/security/api_key.py
+++ b/mass_email_server/app/security/api_key.py
@@ -1,0 +1,16 @@
+from fastapi import Security, HTTPException, status
+from fastapi.security.api_key import APIKeyHeader
+
+from ..config import get_settings
+
+settings = get_settings()
+
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+async def verify_api_key(api_key: str = Security(api_key_header)):
+    if not api_key or api_key != settings.api_key:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid or missing API key",
+        )
+    return api_key

--- a/mass_email_server/requirements.txt
+++ b/mass_email_server/requirements.txt
@@ -1,5 +1,7 @@
 pytest
 pytest-asyncio
+pytest-cov
+httpx
 aiosqlite
 
 

--- a/mass_email_server/tests/test_api_security.py
+++ b/mass_email_server/tests/test_api_security.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi import FastAPI, Depends
+from fastapi.testclient import TestClient
+
+from app.security.api_key import verify_api_key
+
+app = FastAPI()
+
+@app.get("/protected", dependencies=[Depends(verify_api_key)])
+async def protected():
+    return {"ok": True}
+
+client = TestClient(app)
+
+
+def test_protected_success():
+    response = client.get("/protected", headers={"X-API-Key": "changeme"})
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_protected_failure():
+    response = client.get("/protected")
+    assert response.status_code == 403

--- a/mass_email_server/tests/test_template_service.py
+++ b/mass_email_server/tests/test_template_service.py
@@ -1,0 +1,11 @@
+from app.services.template_service import TemplateService
+
+
+def test_template_rendering(tmp_path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    template_file = template_dir / "hello.html"
+    template_file.write_text("Hello {{name}}!")
+    service = TemplateService(template_folder=str(template_dir))
+    result = service.render("hello.html", {"name": "World"})
+    assert result == "Hello World!"


### PR DESCRIPTION
## Summary
- ignore caches and logs
- add API key setting and example configuration
- secure API routes using the new API key dependency
- add unit tests for API key enforcement and template rendering
- include pytest coverage tools and httpx in requirements

## Testing
- `pytest --cov=app -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d6da7b88832ca6a59e85f68aba98