### PR TITLE
Implement frontend scaffolding and new API routes

### DIFF
--- a/mass_email_server/app/main.py
+++ b/mass_email_server/app/main.py
@@ -11,10 +11,16 @@ from .routes.campaigns import router as campaigns_router
 from .routes.templates import router as templates_router
 from .routes.recipients import router as recipients_router
 from .routes.web import router as web_router
+from .routes.dashboard import router as dashboard_router
+from .routes.uploads import router as uploads_router
+from .routes.preview import router as preview_router
+from .routes.analytics import router as analytics_router
+from .routes.settings import router as settings_router
+from .routes.realtime import router as realtime_router
 
 settings = get_settings()
 configure_logging(settings.log_level)
-templates = Jinja2Templates(directory="templates/web_templates")
+templates = Jinja2Templates(directory="app/templates")
 
 app = FastAPI(title="Mass Email Server")
 
@@ -31,6 +37,12 @@ app.include_router(campaigns_router)
 app.include_router(templates_router)
 app.include_router(recipients_router)
 app.include_router(web_router)
+app.include_router(dashboard_router)
+app.include_router(uploads_router)
+app.include_router(preview_router)
+app.include_router(analytics_router)
+app.include_router(settings_router)
+app.include_router(realtime_router)
 
 DATABASE_URL = settings.database_url if settings.env == "development" else settings.postgres_url
 if settings.env == "development" and DATABASE_URL.startswith("sqlite"):
@@ -50,4 +62,4 @@ async def db_session_middleware(request, call_next):
 
 @app.get("/", response_class=HTMLResponse)
 async def root(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse("pages/index.html", {"request": request})

--- a/mass_email_server/app/routes/analytics.py
+++ b/mass_email_server/app/routes/analytics.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends
+from ..security.api_key import verify_api_key
+
+router = APIRouter(
+    prefix="/api/analytics",
+    tags=["analytics"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+@router.get("/campaign/{id}")
+async def campaign_analytics(id: int):
+    return {"campaign": id, "analytics": {}}

--- a/mass_email_server/app/routes/dashboard.py
+++ b/mass_email_server/app/routes/dashboard.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, Depends
+from ..security.api_key import verify_api_key
+
+router = APIRouter(
+    prefix="/api/dashboard",
+    tags=["dashboard"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+@router.get("/metrics")
+async def get_metrics():
+    return {"metrics": []}
+
+@router.get("/recent-activity")
+async def get_recent_activity():
+    return {"recent": []}
+
+@router.get("/system-status")
+async def get_system_status():
+    return {"status": "ok"}

--- a/mass_email_server/app/routes/preview.py
+++ b/mass_email_server/app/routes/preview.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends
+from ..security.api_key import verify_api_key
+
+router = APIRouter(
+    prefix="/api/preview",
+    tags=["preview"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+@router.post("/email")
+async def generate_preview():
+    return {"preview": "<html></html>"}

--- a/mass_email_server/app/routes/realtime.py
+++ b/mass_email_server/app/routes/realtime.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
+from ..security.api_key import verify_api_key
+import asyncio
+
+router = APIRouter(
+    prefix="/api/stream",
+    tags=["realtime"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+async def event_generator(message: str):
+    yield f"data: {message}\n\n"
+    await asyncio.sleep(0.01)
+
+@router.get("/campaign/{id}")
+async def stream_campaign(id: int):
+    async def generator():
+        async for _ in asyncio.as_completed([asyncio.sleep(0.1)]):
+            yield f"data: campaign {id} progress\n\n"
+    return StreamingResponse(generator(), media_type="text/event-stream")
+
+@router.get("/system")
+async def stream_system():
+    return StreamingResponse(event_generator("system"), media_type="text/event-stream")
+
+@router.get("/uploads")
+async def stream_uploads():
+    return StreamingResponse(event_generator("uploads"), media_type="text/event-stream")

--- a/mass_email_server/app/routes/settings.py
+++ b/mass_email_server/app/routes/settings.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+from ..security.api_key import verify_api_key
+
+router = APIRouter(
+    prefix="/api/settings",
+    tags=["settings"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+@router.get("")
+async def get_settings():
+    return {"settings": {}}
+
+@router.post("")
+async def update_settings(payload: dict):
+    return {"updated": payload}

--- a/mass_email_server/app/routes/uploads.py
+++ b/mass_email_server/app/routes/uploads.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, UploadFile, File, Depends
+from ..security.api_key import verify_api_key
+
+router = APIRouter(
+    prefix="/api/uploads",
+    tags=["uploads"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+@router.post("/csv")
+async def upload_csv(file: UploadFile = File(...)):
+    return {"filename": file.filename}
+
+@router.post("/images")
+async def upload_image(file: UploadFile = File(...)):
+    return {"filename": file.filename}
+
+@router.get("/validate-csv")
+async def validate_csv():
+    return {"valid": True}

--- a/mass_email_server/app/static/css/main.css
+++ b/mass_email_server/app/static/css/main.css
@@ -1,0 +1,17 @@
+:root {
+  --primary-50: #f0f9ff;
+  --primary-500: #3b82f6;
+  --primary-900: #1e3a8a;
+
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+
+  --space-1: 0.25rem;
+  --space-4: 1rem;
+  --space-8: 2rem;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+}

--- a/mass_email_server/app/static/css/pages/dashboard.css
+++ b/mass_email_server/app/static/css/pages/dashboard.css
@@ -1,0 +1,1 @@
+.dashboard-heading { font-size: var(--text-lg); }

--- a/mass_email_server/app/static/css/utilities/spacing.css
+++ b/mass_email_server/app/static/css/utilities/spacing.css
@@ -1,0 +1,2 @@
+.m-1 { margin: var(--space-1); }
+.p-4 { padding: var(--space-4); }

--- a/mass_email_server/app/static/js/app.js
+++ b/mass_email_server/app/static/js/app.js
@@ -1,0 +1,7 @@
+import { ComponentRegistry } from './utils/componentRegistry.js';
+
+const registry = new ComponentRegistry();
+
+export function initApp() {
+  registry.init();
+}

--- a/mass_email_server/app/static/js/components/chartComponent.js
+++ b/mass_email_server/app/static/js/components/chartComponent.js
@@ -1,0 +1,7 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class ChartComponent extends BaseComponent {
+  init() {
+    // initialize chart
+  }
+}

--- a/mass_email_server/app/static/js/components/dataTable.js
+++ b/mass_email_server/app/static/js/components/dataTable.js
@@ -1,0 +1,11 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class DataTable extends BaseComponent {
+  init() {
+    this.render();
+  }
+
+  render() {
+    // placeholder render logic
+  }
+}

--- a/mass_email_server/app/static/js/components/formWizard.js
+++ b/mass_email_server/app/static/js/components/formWizard.js
@@ -1,0 +1,7 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class FormWizard extends BaseComponent {
+  init() {
+    // initialize form wizard
+  }
+}

--- a/mass_email_server/app/static/js/components/modal.js
+++ b/mass_email_server/app/static/js/components/modal.js
@@ -1,0 +1,11 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class Modal extends BaseComponent {
+  init() {
+    this.bindEvents();
+  }
+
+  bindEvents() {
+    // placeholder event bindings
+  }
+}

--- a/mass_email_server/app/static/js/services/apiService.js
+++ b/mass_email_server/app/static/js/services/apiService.js
@@ -1,0 +1,7 @@
+export async function apiFetch(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error('API Error');
+  }
+  return response.json();
+}

--- a/mass_email_server/app/static/js/utils/componentRegistry.js
+++ b/mass_email_server/app/static/js/utils/componentRegistry.js
@@ -1,0 +1,25 @@
+export class ComponentRegistry {
+  constructor() {
+    this.components = [];
+  }
+
+  register(component) {
+    this.components.push(component);
+  }
+
+  init() {
+    this.components.forEach((c) => c.init && c.init());
+  }
+}
+
+export class BaseComponent {
+  constructor(element, options = {}) {
+    this.element = element;
+    this.options = options;
+  }
+
+  init() {}
+  render() {}
+  destroy() {}
+  bindEvents() {}
+}

--- a/mass_email_server/app/templates/layouts/base.html
+++ b/mass_email_server/app/templates/layouts/base.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{% block title %}Mass Email Server{% endblock %}</title>
+    <link rel="stylesheet" href="/static/css/main.css">
+</head>
+<body>
+<div class="sidebar">
+    <ul>
+        <li><a href="/">Dashboard</a></li>
+        <li><a href="/campaigns">Campaigns</a></li>
+        <li><a href="/templates">Templates</a></li>
+        <li><a href="/recipients">Recipients</a></li>
+    </ul>
+</div>
+<div class="content">
+    {% block content %}{% endblock %}
+</div>
+<script type="module" src="/static/js/app.js"></script>
+</body>
+</html>

--- a/mass_email_server/app/templates/pages/dashboard.html
+++ b/mass_email_server/app/templates/pages/dashboard.html
@@ -1,0 +1,6 @@
+{% extends 'layouts/base.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1>Dashboard</h1>
+<p>Welcome to the dashboard.</p>
+{% endblock %}

--- a/mass_email_server/app/templates/pages/index.html
+++ b/mass_email_server/app/templates/pages/index.html
@@ -1,0 +1,5 @@
+{% extends 'layouts/base.html' %}
+{% block title %}Home{% endblock %}
+{% block content %}
+<h1>Home</h1>
+{% endblock %}


### PR DESCRIPTION
## Summary
- scaffold static files and template layout
- add dashboard page and home page using new base layout
- implement JavaScript component system and API service helper
- define design system variables in `main.css`
- add FastAPI route placeholders for dashboard, uploads, preview, analytics, settings and realtime streaming
- register new routers in `main.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847df805da8832c8161c6e9aa8e18ed