### PR TITLE
Implement dashboard and campaign management interfaces

### DIFF
--- a/mass_email_server/app/main.py
+++ b/mass_email_server/app/main.py
@@ -17,6 +17,7 @@ from .routes.preview import router as preview_router
 from .routes.analytics import router as analytics_router
 from .routes.settings import router as settings_router
 from .routes.realtime import router as realtime_router
+from .routes.campaign_drafts import router as campaign_drafts_router
 
 settings = get_settings()
 configure_logging(settings.log_level)
@@ -40,6 +41,7 @@ app.include_router(web_router)
 app.include_router(dashboard_router)
 app.include_router(uploads_router)
 app.include_router(preview_router)
+app.include_router(campaign_drafts_router)
 app.include_router(analytics_router)
 app.include_router(settings_router)
 app.include_router(realtime_router)
@@ -63,3 +65,8 @@ async def db_session_middleware(request, call_next):
 @app.get("/", response_class=HTMLResponse)
 async def root(request: Request):
     return templates.TemplateResponse("pages/index.html", {"request": request})
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+async def dashboard_page(request: Request):
+    return templates.TemplateResponse("pages/dashboard.html", {"request": request})

--- a/mass_email_server/app/models/__init__.py
+++ b/mass_email_server/app/models/__init__.py
@@ -1,2 +1,4 @@
 from .database import Base
 from .database import EmailCampaign, EmailRecipient, EmailTemplate, EmailLog
+
+from .database import CampaignDraft, CampaignAnalytics

--- a/mass_email_server/app/models/database.py
+++ b/mass_email_server/app/models/database.py
@@ -49,3 +49,20 @@ class EmailLog(Base):
     status = Column(String)
     error_message = Column(Text)
     timestamp = Column(DateTime, default=datetime.utcnow)
+
+class CampaignDraft(Base):
+    __tablename__ = "campaign_drafts"
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer)
+    wizard_data = Column(Text)
+    step_completed = Column(Integer, default=0)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+class CampaignAnalytics(Base):
+    __tablename__ = "campaign_analytics"
+    id = Column(Integer, primary_key=True, index=True)
+    campaign_id = Column(Integer, ForeignKey("email_campaigns.id"))
+    metric_name = Column(String(50))
+    metric_value = Column(Integer)
+    recorded_at = Column(DateTime, default=datetime.utcnow)

--- a/mass_email_server/app/models/email_models.py
+++ b/mass_email_server/app/models/email_models.py
@@ -22,3 +22,14 @@ class EmailLog(BaseModel):
     status: str
     error_message: Optional[str]
     timestamp: datetime
+
+class CampaignDraftCreate(BaseModel):
+    user_id: Optional[int] = None
+    wizard_data: dict
+    step_completed: int = 0
+
+class CampaignAnalyticsCreate(BaseModel):
+    campaign_id: int
+    metric_name: str
+    metric_value: float
+    recorded_at: Optional[datetime] = None

--- a/mass_email_server/app/routes/analytics.py
+++ b/mass_email_server/app/routes/analytics.py
@@ -1,5 +1,9 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from ..security.api_key import verify_api_key
+from ..models.database import CampaignAnalytics
 
 router = APIRouter(
     prefix="/api/analytics",
@@ -8,5 +12,16 @@ router = APIRouter(
 )
 
 @router.get("/campaign/{id}")
-async def campaign_analytics(id: int):
-    return {"campaign": id, "analytics": {}}
+async def campaign_analytics(id: int, request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(CampaignAnalytics).where(CampaignAnalytics.campaign_id == id))
+    records = result.scalars().all()
+    analytics = [
+        {
+            "metric_name": r.metric_name,
+            "metric_value": r.metric_value,
+            "recorded_at": r.recorded_at,
+        }
+        for r in records
+    ]
+    return {"campaign": id, "analytics": analytics}

--- a/mass_email_server/app/routes/campaign_drafts.py
+++ b/mass_email_server/app/routes/campaign_drafts.py
@@ -1,0 +1,52 @@
+from fastapi import APIRouter, Request, HTTPException, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..models.database import CampaignDraft
+from ..models.email_models import CampaignDraftCreate
+from ..security.api_key import verify_api_key
+
+router = APIRouter(
+    prefix="/api/campaigns/drafts",
+    tags=["campaign_drafts"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+@router.post("", status_code=201)
+async def create_draft(draft: CampaignDraftCreate, request: Request):
+    db: AsyncSession = request.state.db
+    new_draft = CampaignDraft(
+        user_id=draft.user_id,
+        wizard_data=str(draft.wizard_data),
+        step_completed=draft.step_completed,
+    )
+    db.add(new_draft)
+    await db.commit()
+    await db.refresh(new_draft)
+    return {"id": new_draft.id}
+
+@router.get("/{draft_id}")
+async def get_draft(draft_id: int, request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(CampaignDraft).where(CampaignDraft.id == draft_id))
+    draft = result.scalar_one_or_none()
+    if draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+    return {
+        "id": draft.id,
+        "user_id": draft.user_id,
+        "wizard_data": draft.wizard_data,
+        "step_completed": draft.step_completed,
+    }
+
+@router.put("/{draft_id}")
+async def update_draft(draft_id: int, draft: CampaignDraftCreate, request: Request):
+    db: AsyncSession = request.state.db
+    result = await db.execute(select(CampaignDraft).where(CampaignDraft.id == draft_id))
+    db_draft = result.scalar_one_or_none()
+    if db_draft is None:
+        raise HTTPException(status_code=404, detail="Draft not found")
+    db_draft.wizard_data = str(draft.wizard_data)
+    db_draft.step_completed = draft.step_completed
+    await db.commit()
+    return {"ok": True}

--- a/mass_email_server/app/routes/web.py
+++ b/mass_email_server/app/routes/web.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models.database import EmailCampaign
 
-templates = Jinja2Templates(directory="templates/web_templates")
+templates = Jinja2Templates(directory="app/templates")
 
 router = APIRouter()
 
@@ -15,11 +15,14 @@ async def campaigns_page(request: Request):
     db: AsyncSession = request.state.db
     result = await db.execute(select(EmailCampaign))
     campaigns = result.scalars().all()
-    return templates.TemplateResponse("campaigns.html", {"request": request, "campaigns": campaigns})
+    return templates.TemplateResponse(
+        "pages/campaigns.html",
+        {"request": request, "campaigns": campaigns},
+    )
 
 @router.get("/campaigns/new", response_class=HTMLResponse)
 async def new_campaign_form(request: Request):
-    return templates.TemplateResponse("new_campaign.html", {"request": request})
+    return templates.TemplateResponse("pages/campaign_wizard.html", {"request": request})
 
 @router.post("/campaigns/new")
 async def create_campaign_form(request: Request, name: str = Form(...), subject: str = Form(...), html_content: str = Form(...)):

--- a/mass_email_server/app/static/js/app.js
+++ b/mass_email_server/app/static/js/app.js
@@ -1,7 +1,35 @@
 import { ComponentRegistry } from './utils/componentRegistry.js';
+import { ChartComponent } from './components/chartComponent.js';
+import { DataTable } from './components/dataTable.js';
+import { FormWizard } from './components/formWizard.js';
+import { Modal } from './components/modal.js';
+import { MetricCard } from './components/metricCard.js';
+import { ActivityFeed } from './components/activityFeed.js';
+import { QuickActions } from './components/quickActions.js';
+import { CampaignManager } from './components/campaignManager.js';
+import { CampaignWizard } from './components/campaignWizard.js';
 
 const registry = new ComponentRegistry();
 
+const componentMap = {
+  ChartContainer: ChartComponent,
+  DataTable: DataTable,
+  FormWizard: FormWizard,
+  Modal: Modal,
+  MetricCard: MetricCard,
+  ActivityFeed: ActivityFeed,
+  QuickActions: QuickActions,
+  CampaignManager: CampaignManager,
+  CampaignWizard: CampaignWizard,
+};
+
 export function initApp() {
+  document.querySelectorAll('[data-component]').forEach((el) => {
+    const name = el.dataset.component;
+    const Comp = componentMap[name];
+    if (Comp) {
+      registry.register(new Comp(el));
+    }
+  });
   registry.init();
 }

--- a/mass_email_server/app/static/js/components/activityFeed.js
+++ b/mass_email_server/app/static/js/components/activityFeed.js
@@ -1,0 +1,11 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class ActivityFeed extends BaseComponent {
+  init() {
+    this.render();
+  }
+
+  render() {
+    this.element.innerHTML = `<ul class="activity-list"></ul>`;
+  }
+}

--- a/mass_email_server/app/static/js/components/campaignManager.js
+++ b/mass_email_server/app/static/js/components/campaignManager.js
@@ -1,0 +1,11 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class CampaignManager extends BaseComponent {
+  init() {
+    this.render();
+  }
+
+  render() {
+    this.element.querySelector('.data-table').innerHTML = '<thead><tr><th>Name</th><th>Status</th></tr></thead><tbody></tbody>';
+  }
+}

--- a/mass_email_server/app/static/js/components/campaignWizard.js
+++ b/mass_email_server/app/static/js/components/campaignWizard.js
@@ -1,0 +1,31 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class CampaignWizard extends BaseComponent {
+  init() {
+    this.currentStep = 1;
+    this.bindEvents();
+  }
+
+  bindEvents() {
+    const nextBtn = this.element.querySelector('.btn--primary');
+    const prevBtn = this.element.querySelector('.btn--secondary');
+    if (nextBtn) nextBtn.addEventListener('click', () => this.next());
+    if (prevBtn) prevBtn.addEventListener('click', () => this.prev());
+  }
+
+  showStep(step) {
+    this.element.querySelectorAll('.step-panel').forEach((p) => p.classList.remove('active'));
+    const panel = this.element.querySelector(`[data-step="${step}"]`);
+    if (panel) panel.classList.add('active');
+  }
+
+  next() {
+    this.currentStep = Math.min(5, this.currentStep + 1);
+    this.showStep(this.currentStep);
+  }
+
+  prev() {
+    this.currentStep = Math.max(1, this.currentStep - 1);
+    this.showStep(this.currentStep);
+  }
+}

--- a/mass_email_server/app/static/js/components/chartComponent.js
+++ b/mass_email_server/app/static/js/components/chartComponent.js
@@ -2,6 +2,31 @@ import { BaseComponent } from '../utils/componentRegistry.js';
 
 export class ChartComponent extends BaseComponent {
   init() {
-    // initialize chart
+    this.render();
+  }
+
+  render() {
+    if (!window.Chart) {
+      return;
+    }
+    const ctx = document.createElement('canvas');
+    this.element.appendChild(ctx);
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+        datasets: [
+          {
+            label: 'Emails Sent',
+            data: [12, 19, 3, 5, 2],
+            backgroundColor: 'rgba(54, 162, 235, 0.5)'
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false
+      }
+    });
   }
 }

--- a/mass_email_server/app/static/js/components/metricCard.js
+++ b/mass_email_server/app/static/js/components/metricCard.js
@@ -1,0 +1,23 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class MetricCard extends BaseComponent {
+  init() {
+    this.render();
+  }
+
+  render() {
+    this.element.innerHTML = `
+      <div class="metric">
+        <h3>Total Campaigns</h3>
+        <span class="metric-value" id="total-campaigns">0</span>
+      </div>
+      <div class="metric">
+        <h3>Emails Sent Today</h3>
+        <span class="metric-value" id="emails-sent">0</span>
+      </div>
+      <div class="metric">
+        <h3>Delivery Rate</h3>
+        <span class="metric-value" id="delivery-rate">0%</span>
+      </div>`;
+  }
+}

--- a/mass_email_server/app/static/js/components/quickActions.js
+++ b/mass_email_server/app/static/js/components/quickActions.js
@@ -1,0 +1,13 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class QuickActions extends BaseComponent {
+  init() {
+    this.render();
+  }
+
+  render() {
+    this.element.innerHTML = `
+      <button class="btn" onclick="location.href='/campaigns/new'">New Campaign</button>
+    `;
+  }
+}

--- a/mass_email_server/app/templates/layouts/base.html
+++ b/mass_email_server/app/templates/layouts/base.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>{% block title %}Mass Email Server{% endblock %}</title>
     <link rel="stylesheet" href="/static/css/main.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
 </head>
 <body>
 <div class="sidebar">

--- a/mass_email_server/app/templates/pages/campaign_wizard.html
+++ b/mass_email_server/app/templates/pages/campaign_wizard.html
@@ -1,0 +1,26 @@
+{% extends 'layouts/base.html' %}
+{% block title %}New Campaign{% endblock %}
+{% block content %}
+<div class="campaign-wizard" data-component="CampaignWizard">
+  <nav class="wizard__progress">
+    <ol class="progress-steps">
+      <li class="step active">Details</li>
+      <li class="step">Template</li>
+      <li class="step">Recipients</li>
+      <li class="step">Schedule</li>
+      <li class="step">Review</li>
+    </ol>
+  </nav>
+  <main class="wizard__content">
+    <div class="step-panel active" data-step="1"></div>
+    <div class="step-panel" data-step="2"></div>
+    <div class="step-panel" data-step="3"></div>
+    <div class="step-panel" data-step="4"></div>
+    <div class="step-panel" data-step="5"></div>
+  </main>
+  <footer class="wizard__actions">
+    <button class="btn btn--secondary">Previous</button>
+    <button class="btn btn--primary">Next</button>
+  </footer>
+</div>
+{% endblock %}

--- a/mass_email_server/app/templates/pages/campaigns.html
+++ b/mass_email_server/app/templates/pages/campaigns.html
@@ -1,0 +1,15 @@
+{% extends 'layouts/base.html' %}
+{% block title %}Campaigns{% endblock %}
+{% block content %}
+<div class="campaign-manager" data-component="CampaignManager">
+  <header class="campaign-manager__toolbar">
+    <div class="search-bar" data-component="SearchBar"></div>
+    <div class="filter-panel" data-component="FilterPanel"></div>
+    <div class="action-buttons" data-component="ActionButtons"></div>
+  </header>
+  <main class="campaign-manager__table">
+    <table class="data-table" data-component="DataTable"></table>
+    <div class="pagination" data-component="Pagination"></div>
+  </main>
+</div>
+{% endblock %}

--- a/mass_email_server/app/templates/pages/dashboard.html
+++ b/mass_email_server/app/templates/pages/dashboard.html
@@ -1,6 +1,18 @@
 {% extends 'layouts/base.html' %}
 {% block title %}Dashboard{% endblock %}
 {% block content %}
-<h1>Dashboard</h1>
-<p>Welcome to the dashboard.</p>
+<main class="dashboard">
+  <section class="dashboard__metrics">
+    <div class="metric-card" data-component="MetricCard"></div>
+  </section>
+  <section class="dashboard__charts">
+    <div class="chart-container" data-component="ChartContainer"></div>
+  </section>
+  <section class="dashboard__activity">
+    <div class="activity-feed" data-component="ActivityFeed"></div>
+  </section>
+  <section class="dashboard__quick-actions">
+    <div class="action-panel" data-component="QuickActions"></div>
+  </section>
+</main>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add new models for campaign drafts and analytics
- implement API endpoints for campaign drafts and analytics
- create dashboard, campaign manager, and campaign wizard pages
- add associated JS components and Chart.js integration
- include new routes for pages and register components

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847e0e6eb30832c8022f647287c7213