### PR TITLE
Add GrapesJS editor and MJML preview support

### DIFF
--- a/mass_email_server/README.md
+++ b/mass_email_server/README.md
@@ -21,6 +21,11 @@ This is a FastAPI-based mass email server. It includes SMTP connection managemen
    uvicorn app.main:app --reload
    ```
 
+## Template Editor
+
+The web interface now includes a template editor powered by [GrapesJS](https://github.com/GrapesJS/grapesjs).
+Visit `/templates/editor` to design HTML emails with drag-and-drop blocks. Templates can also be rendered with MJML and have their CSS inlined using `premailer`.
+
 ## Tests
 
 Run tests with:

--- a/mass_email_server/app/routes/web.py
+++ b/mass_email_server/app/routes/web.py
@@ -31,3 +31,8 @@ async def create_campaign_form(request: Request, name: str = Form(...), subject:
     db.add(campaign)
     await db.commit()
     return RedirectResponse(url="/campaigns", status_code=303)
+
+
+@router.get("/templates/editor", response_class=HTMLResponse)
+async def template_editor(request: Request):
+    return templates.TemplateResponse("pages/template_editor.html", {"request": request})

--- a/mass_email_server/app/services/template_service.py
+++ b/mass_email_server/app/services/template_service.py
@@ -1,4 +1,6 @@
 from jinja2 import Environment, FileSystemLoader, Template
+from premailer import transform
+from mjml import mjml_to_html
 
 class TemplateService:
     def __init__(self, template_folder: str = 'templates/email_templates'):
@@ -7,3 +9,12 @@ class TemplateService:
     def render(self, template_name: str, context: dict) -> str:
         template: Template = self.env.get_template(template_name)
         return template.render(**context)
+
+    def render_mjml(self, mjml_source: str, context: dict) -> str:
+        template = self.env.from_string(mjml_source)
+        mjml_rendered = template.render(**context)
+        result = mjml_to_html(mjml_rendered)
+        return result['html']
+
+    def inline_css(self, html: str) -> str:
+        return transform(html)

--- a/mass_email_server/app/static/js/app.js
+++ b/mass_email_server/app/static/js/app.js
@@ -8,6 +8,7 @@ import { ActivityFeed } from './components/activityFeed.js';
 import { QuickActions } from './components/quickActions.js';
 import { CampaignManager } from './components/campaignManager.js';
 import { CampaignWizard } from './components/campaignWizard.js';
+import { TemplateEditor } from './components/templateEditor.js';
 
 const registry = new ComponentRegistry();
 
@@ -21,6 +22,7 @@ const componentMap = {
   QuickActions: QuickActions,
   CampaignManager: CampaignManager,
   CampaignWizard: CampaignWizard,
+  TemplateEditor: TemplateEditor,
 };
 
 export function initApp() {

--- a/mass_email_server/app/static/js/components/templateEditor.js
+++ b/mass_email_server/app/static/js/components/templateEditor.js
@@ -1,0 +1,13 @@
+import { BaseComponent } from '../utils/componentRegistry.js';
+
+export class TemplateEditor extends BaseComponent {
+  init() {
+    if (window.grapesjs) {
+      this.editor = window.grapesjs.init({
+        container: this.element,
+        height: '600px',
+        fromElement: true,
+      });
+    }
+  }
+}

--- a/mass_email_server/app/templates/layouts/base.html
+++ b/mass_email_server/app/templates/layouts/base.html
@@ -11,7 +11,7 @@
     <ul>
         <li><a href="/">Dashboard</a></li>
         <li><a href="/campaigns">Campaigns</a></li>
-        <li><a href="/templates">Templates</a></li>
+        <li><a href="/templates/editor">Templates</a></li>
         <li><a href="/recipients">Recipients</a></li>
     </ul>
 </div>

--- a/mass_email_server/app/templates/pages/template_editor.html
+++ b/mass_email_server/app/templates/pages/template_editor.html
@@ -1,0 +1,7 @@
+{% extends 'layouts/base.html' %}
+{% block title %}Template Editor{% endblock %}
+{% block content %}
+<div class="template-editor" data-component="TemplateEditor"></div>
+<script src="https://unpkg.com/grapesjs@0.21.4/dist/grapes.min.js"></script>
+<link href="https://unpkg.com/grapesjs@0.21.4/dist/css/grapes.min.css" rel="stylesheet"/>
+{% endblock %}

--- a/mass_email_server/requirements.txt
+++ b/mass_email_server/requirements.txt
@@ -17,3 +17,5 @@ email-validator
 psycopg2-binary
 alembic
 python-multipart
+premailer
+mjml

--- a/mass_email_server/tests/test_template_service.py
+++ b/mass_email_server/tests/test_template_service.py
@@ -9,3 +9,19 @@ def test_template_rendering(tmp_path):
     service = TemplateService(template_folder=str(template_dir))
     result = service.render("hello.html", {"name": "World"})
     assert result == "Hello World!"
+
+
+def test_render_mjml(tmp_path):
+    template_dir = tmp_path / "templates"
+    template_dir.mkdir()
+    service = TemplateService(template_folder=str(template_dir))
+    mjml_source = "<mjml><mj-body><mj-section><mj-column><mj-text>Hello {{name}}!</mj-text></mj-column></mj-section></mj-body></mjml>"
+    html = service.render_mjml(mjml_source, {"name": "Alice"})
+    assert "Hello Alice!" in html
+
+
+def test_inline_css():
+    service = TemplateService()
+    html = "<style>h1{color:red;}</style><h1>Hello</h1>"
+    inlined = service.inline_css(html)
+    assert "style=\"color:red" in inlined


### PR DESCRIPTION
## Summary
- integrate GrapesJS in a new template editor page
- register new TemplateEditor JS component
- add MJML & Premailer utilities in TemplateService
- link sidebar to `/templates/editor`
- document template editor in README
- include dependencies in requirements
- add tests for MJML rendering and CSS inlining

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847e281303c832c82875385aeb36eb6